### PR TITLE
Update README.md to use proper gemname

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you want to query the FeatureService and MapService endpoitns, then check out
 
 Just install using Rubygems:
 
-`gem install geoservices`
+`gem install arcgis`
 
 ## Instructions
 


### PR DESCRIPTION
per specfile should this be 'arcgis'?  I confirmed it at rubygems.org as well.